### PR TITLE
Strict linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,40 @@
+linters:
+  enable-all: true
+  disable:
+    - wrapcheck # TODO fix
+    - goerr113 # TODO fix
+    - varnamelen
+    - testpackage
+    - nosnakecase
+    - nonamedreturns
+    - nlreturn
+    - ireturn
+    - gomnd
+    - ifshort
+    - exhaustivestruct
+    - exhaustruct
+    - goconst
+    - godox
+    - depguard
+    - wsl
+    - lll
+    - cyclop
+    - gocognit
+    - gocyclo
+    - maintidx
+    # deprecated linters
+    - deadcode
+    - interfacer
+    - scopelint
+    - varcheck
+    - structcheck
+    - maligned
+    - funlen
+    - golint
+
 issues:
   exclude-rules:
     - path: _test\.go
       linters:
         - errcheck
+        - forcetypeassert

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,13 +2,15 @@ linters:
   enable-all: true
   disable:
     - wrapcheck # TODO fix
-    - goerr113 # TODO fix
+    - err113 # TODO fix
+    - testifylint # TODO fix
     - varnamelen
     - testpackage
     - nosnakecase
     - nonamedreturns
     - nlreturn
     - ireturn
+    - mnd
     - gomnd
     - ifshort
     - exhaustivestruct
@@ -31,6 +33,7 @@ linters:
     - maligned
     - funlen
     - golint
+    - execinquery
 
 issues:
   exclude-rules:

--- a/annotation_test.go
+++ b/annotation_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAnnotation(t *testing.T) {
+	t.Parallel()
 	cf, err := parseFile("./testdata/classes/main/Test.class")
 	assert.NoError(t, err)
 

--- a/attribute.go
+++ b/attribute.go
@@ -3,8 +3,8 @@ package parser
 import "github.com/wreulicke/classfile-parser/code"
 
 var (
-	deprecated = &AttributeDeprecated{}
-	synthetic  = &AttributeSynthetic{}
+	deprecated = &AttributeDeprecated{} //nolint:gochecknoglobals
+	synthetic  = &AttributeSynthetic{}  //nolint:gochecknoglobals
 )
 
 type Attribute interface {

--- a/attribute_stackframe.go
+++ b/attribute_stackframe.go
@@ -70,6 +70,7 @@ type (
 		CpoolIndex uint16
 	}
 )
+
 type VerificationTypeInfoUninitializedVaribleInfo struct {
 	Offset uint16
 }

--- a/attribute_stackframe.go
+++ b/attribute_stackframe.go
@@ -51,25 +51,29 @@ type StackMapFrameFullFrame struct {
 type VerificationTypeInfo interface{}
 
 var (
-	_verificationTypeInfoTopVaribleInfo               = &VerificationTypeInfoDoubleVaribleInfo{}
-	_verificationTypeInfoIntegerVaribleInfo           = &VerificationTypeInfoIntegerVaribleInfo{}
-	_verificationTypeInfoFloatVaribleInfo             = &VerificationTypeInfoIntegerVaribleInfo{}
-	_verificationTypeInfoNullVaribleInfo              = &VerificationTypeInfoNullVaribleInfo{}
-	_verificationTypeInfoUninitializedThisVaribleInfo = &VerificationTypeInfoUninitializedThisVaribleInfo{}
-	_verificationTypeInfoLongVaribleInfo              = &VerificationTypeInfoLongVaribleInfo{}
-	_verificationTypeInfoDoubleVaribleInfo            = &VerificationTypeInfoDoubleVaribleInfo{}
+	_verificationTypeInfoTopVaribleInfo               = &VerificationTypeInfoDoubleVaribleInfo{}            //nolint:gochecknoglobals
+	_verificationTypeInfoIntegerVaribleInfo           = &VerificationTypeInfoIntegerVaribleInfo{}           //nolint:gochecknoglobals
+	_verificationTypeInfoFloatVaribleInfo             = &VerificationTypeInfoIntegerVaribleInfo{}           //nolint:gochecknoglobals
+	_verificationTypeInfoNullVaribleInfo              = &VerificationTypeInfoNullVaribleInfo{}              //nolint:gochecknoglobals
+	_verificationTypeInfoUninitializedThisVaribleInfo = &VerificationTypeInfoUninitializedThisVaribleInfo{} //nolint:gochecknoglobals
+	_verificationTypeInfoLongVaribleInfo              = &VerificationTypeInfoLongVaribleInfo{}              //nolint:gochecknoglobals
+	_verificationTypeInfoDoubleVaribleInfo            = &VerificationTypeInfoDoubleVaribleInfo{}            //nolint:gochecknoglobals
 )
 
-type VerificationTypeInfoTopVaribleInfo struct{}
-type VerificationTypeInfoIntegerVaribleInfo struct{}
-type VerificationTypeInfoFloatVaribleInfo struct{}
-type VerificationTypeInfoNullVaribleInfo struct{}
-type VerificationTypeInfoUninitializedThisVaribleInfo struct{}
-type VerificationTypeInfoObjectVaribleInfo struct {
-	CpoolIndex uint16
-}
+type (
+	VerificationTypeInfoTopVaribleInfo               struct{}
+	VerificationTypeInfoIntegerVaribleInfo           struct{}
+	VerificationTypeInfoFloatVaribleInfo             struct{}
+	VerificationTypeInfoNullVaribleInfo              struct{}
+	VerificationTypeInfoUninitializedThisVaribleInfo struct{}
+	VerificationTypeInfoObjectVaribleInfo            struct {
+		CpoolIndex uint16
+	}
+)
 type VerificationTypeInfoUninitializedVaribleInfo struct {
 	Offset uint16
 }
-type VerificationTypeInfoLongVaribleInfo struct{}
-type VerificationTypeInfoDoubleVaribleInfo struct{}
+type (
+	VerificationTypeInfoLongVaribleInfo   struct{}
+	VerificationTypeInfoDoubleVaribleInfo struct{}
+)

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -16,6 +16,7 @@ func findAttribute(attrs []Attribute, name string) Attribute {
 }
 
 func TestParseCode(t *testing.T) {
+	t.Parallel()
 	cf, err := parseFile("./testdata/classes/main/Test.class")
 	assert.NoError(t, err)
 

--- a/binary/binary_parser.go
+++ b/binary/binary_parser.go
@@ -34,7 +34,7 @@ func (p *parser) ReadBytes(size int) ([]byte, error) {
 	bs := make([]byte, size)
 	n, err := io.ReadFull(p.input, bs)
 	if n != size {
-		return nil, fmt.Errorf("Cannot read %d bytes. got %d bytes", size, n)
+		return nil, fmt.Errorf("cannot read %d bytes. got %d bytes", size, n)
 	}
 	if err != nil {
 		return nil, err

--- a/code/opcodes.go
+++ b/code/opcodes.go
@@ -1,3 +1,4 @@
+//nolint:stylecheck,revive
 package code
 
 type opcode uint8

--- a/code/parser.go
+++ b/code/parser.go
@@ -2,6 +2,7 @@ package code
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 
@@ -265,7 +266,7 @@ func (p *codeParser) Parse() ([]*Instruction, error) {
 	var instructions []*Instruction
 	for {
 		inst, err := p.parseInstruction()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			instructions = append(instructions, inst)
 			return instructions, nil
 		} else if err != nil {
@@ -282,7 +283,7 @@ func (p *codeParser) parseInstruction() (*Instruction, error) {
 	}
 	parse, ok := p.opcodeParseFns[opcode(b)]
 	if !ok {
-		return nil, fmt.Errorf("Unknown opcode. %d", b)
+		return nil, fmt.Errorf("unknown opcode. %d", b)
 	}
 	inst := &Instruction{
 		opcode: opcode(b),

--- a/code/parser.go
+++ b/code/parser.go
@@ -17,7 +17,7 @@ type codeParser struct {
 
 type opcodeParseFn func(*Instruction) error
 
-type CodeParser interface {
+type CodeParser interface { //nolint:revive
 	Parse() ([]*Instruction, error)
 }
 
@@ -295,7 +295,7 @@ func (p *codeParser) registerOpcodeParseFn(code opcode, fn opcodeParseFn) {
 	p.opcodeParseFns[code] = fn
 }
 
-func (p *codeParser) nop(inst *Instruction) error {
+func (p *codeParser) nop(_ *Instruction) error {
 	return nil
 }
 
@@ -352,10 +352,7 @@ func (p *codeParser) parseMultianewarray(inst *Instruction) error {
 	if err != nil {
 		return err
 	}
-	if err := p.take1Operand(inst); err != nil {
-		return err
-	}
-	return nil
+	return p.take1Operand(inst)
 }
 
 func (p *codeParser) parseLookupSwitch(inst *Instruction) error {

--- a/code/parser.go
+++ b/code/parser.go
@@ -273,7 +273,6 @@ func (p *codeParser) Parse() ([]*Instruction, error) {
 		}
 		instructions = append(instructions, inst)
 	}
-
 }
 
 func (p *codeParser) parseInstruction() (*Instruction, error) {

--- a/constant_pool.go
+++ b/constant_pool.go
@@ -12,7 +12,7 @@ type ConstantPool struct {
 var ErrNotFoundConstant = errors.New("not found constant")
 
 func (c *ConstantPool) LookupUtf8(index uint16) *ConstantUtf8 {
-	var i int = int(index) - 1
+	i := int(index) - 1
 	if i < 0 {
 		return nil
 	} else if i > len(c.Constants) {
@@ -26,7 +26,7 @@ func (c *ConstantPool) LookupUtf8(index uint16) *ConstantUtf8 {
 }
 
 func (c *ConstantPool) GetConstantUtf8(index uint16) (*ConstantUtf8, error) {
-	var i int = int(index) - 1
+	i := int(index) - 1
 	if i < 0 || i > len(c.Constants) {
 		return nil, ErrNotFoundConstant
 	}
@@ -38,7 +38,7 @@ func (c *ConstantPool) GetConstantUtf8(index uint16) (*ConstantUtf8, error) {
 }
 
 func (c *ConstantPool) GetClassInfo(index uint16) (*ConstantClass, error) {
-	var i int = int(index) - 1
+	i := int(index) - 1
 	if i < 0 || i > len(c.Constants) {
 		return nil, ErrNotFoundConstant
 	}
@@ -50,7 +50,7 @@ func (c *ConstantPool) GetClassInfo(index uint16) (*ConstantClass, error) {
 }
 
 func (c *ConstantPool) GetClassName(classNameIndex uint16) (string, error) {
-	var i int = int(classNameIndex)
+	i := int(classNameIndex)
 	if i < 1 || i > len(c.Constants) {
 		return "", ErrNotFoundConstant
 	}

--- a/constant_pool.go
+++ b/constant_pool.go
@@ -32,7 +32,7 @@ func (c *ConstantPool) GetConstantUtf8(index uint16) (*ConstantUtf8, error) {
 	}
 	clazz, ok := c.Constants[i].(*ConstantUtf8)
 	if !ok {
-		return nil, fmt.Errorf("Unexpected constant. expected:ConstantUtf8, actual: %T", c.Constants[i])
+		return nil, fmt.Errorf("unexpected constant. expected:ConstantUtf8, actual: %T", c.Constants[i])
 	}
 	return clazz, nil
 }
@@ -44,7 +44,7 @@ func (c *ConstantPool) GetClassInfo(index uint16) (*ConstantClass, error) {
 	}
 	clazz, ok := c.Constants[i].(*ConstantClass)
 	if !ok {
-		return nil, fmt.Errorf("Unexpected constant. expected:ConstantClass, actual: %T", c.Constants[i])
+		return nil, fmt.Errorf("unexpected constant. expected:ConstantClass, actual: %T", c.Constants[i])
 	}
 	return clazz, nil
 }
@@ -65,8 +65,7 @@ func (c *ConstantPool) GetClassName(classNameIndex uint16) (string, error) {
 	return name.String(), nil
 }
 
-type Constant interface {
-}
+type Constant interface{}
 
 type ConstantClass struct {
 	NameIndex uint16

--- a/field_test.go
+++ b/field_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestReadFieldName(t *testing.T) {
+	t.Parallel()
 	cf, err := parseFile("./testdata/classes/main/Test.class")
 	assert.NoError(t, err)
 

--- a/method_test.go
+++ b/method_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestReadMethodName(t *testing.T) {
+	t.Parallel()
 	cf, err := parseFile("./testdata/classes/main/Test.class")
 	assert.NoError(t, err)
 
@@ -19,6 +20,7 @@ func TestReadMethodName(t *testing.T) {
 }
 
 func TestAnnotationDefault(t *testing.T) {
+	t.Parallel()
 	cf, err := parseFile("./testdata/classes/main/Annot.class")
 	assert.NoError(t, err)
 

--- a/parser.go
+++ b/parser.go
@@ -99,6 +99,7 @@ func (p *Parser) readConstantPool(c *Classfile) error {
 		if err != nil {
 			return err
 		}
+		// See https://docs.oracle.com/javase/specs/jvms/se22/html/jvms-4.html#jvms-4.4-210
 		switch tag {
 		case 7:
 			c := &ConstantClass{}

--- a/parser.go
+++ b/parser.go
@@ -264,7 +264,7 @@ func (p *Parser) readConstantPool(c *Classfile) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("Unsupported tags for constant pool. tag:%d", tag)
+			return fmt.Errorf("unsupported tags for constant pool. tag:%d", tag)
 		}
 	}
 	return nil
@@ -1053,7 +1053,7 @@ func readStackMapFrame(parser binary.Parser) (StackMapFrame, error) {
 		}
 		return f, nil
 	}
-	return nil, errors.New("Not supported frame type")
+	return nil, errors.New("not supported frame type")
 }
 
 func readVerificationType(parser binary.Parser) (VerificationTypeInfo, error) {
@@ -1086,7 +1086,7 @@ func readVerificationType(parser binary.Parser) (VerificationTypeInfo, error) {
 	case 3:
 		return _verificationTypeInfoDoubleVaribleInfo, nil
 	}
-	return nil, errors.New("Unsupported verification type info")
+	return nil, errors.New("unsupported verification type info")
 }
 
 func readAnnotation(parser binary.Parser) (*Annotation, error) {
@@ -1199,7 +1199,7 @@ func readTypeAnnotation(parser binary.Parser) (*TypeAnnotation, error) {
 	case 0x4B:
 		a.TargetInfo, err = readTypeArgumentTarget(parser)
 	default:
-		return nil, fmt.Errorf("Unsupported target type for TypeAnnotation. tag: %d", targetType)
+		return nil, fmt.Errorf("unsupported target type for TypeAnnotation. tag: %d", targetType)
 	}
 	if err != nil {
 		return nil, err
@@ -1368,7 +1368,7 @@ func readElementValue(parser binary.Parser) (ElementValue, error) {
 	case '[':
 		return readElementArrayValue(parser)
 	default:
-		return nil, errors.New("Unsupported tag for element value")
+		return nil, errors.New("unsupported tag for element value")
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -97,7 +97,7 @@ func (p *Parser) readConstantPool(c *Classfile) error {
 	for ; i < count-1; i++ {
 		tag, err := p.ReadUint8()
 		if err != nil {
-			return nil
+			return err
 		}
 		switch tag {
 		case 7:
@@ -1150,6 +1150,7 @@ func readTypeAnnotation(parser binary.Parser) (*TypeAnnotation, error) {
 	if err != nil {
 		return nil, err
 	}
+	// See https://docs.oracle.com/javase/specs/jvms/se22/html/jvms-4.html#jvms-4.7.20-400
 	switch targetType {
 	case 0x00:
 		a.TargetInfo, err = readTypeParameterTarget(parser)

--- a/parser.go
+++ b/parser.go
@@ -266,7 +266,6 @@ func (p *Parser) readConstantPool(c *Classfile) error {
 		default:
 			return fmt.Errorf("Unsupported tags for constant pool. tag:%d", tag)
 		}
-
 	}
 	return nil
 }
@@ -1062,6 +1061,7 @@ func readVerificationType(parser binary.Parser) (VerificationTypeInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	// See https://docs.oracle.com/javase/specs/jvms/se22/html/jvms-4.html#jvms-4.7.4
 	switch tag {
 	case 0:
 		return _verificationTypeInfoTopVaribleInfo, nil
@@ -1145,6 +1145,7 @@ func readParameterAnnotation(parser binary.Parser) (*ParameterAnnotation, error)
 	return a, nil
 }
 
+// readTypeAnnotation reads a type annotation.
 func readTypeAnnotation(parser binary.Parser) (*TypeAnnotation, error) {
 	a := &TypeAnnotation{}
 	targetType, err := parser.ReadUint8()

--- a/parser_test.go
+++ b/parser_test.go
@@ -19,6 +19,7 @@ func parseFile(path string) (*Classfile, error) {
 }
 
 func TestParse(t *testing.T) {
+	t.Parallel()
 	filepath.Walk("./testdata", func(path string, info os.FileInfo, err error) error {
 		if !strings.HasSuffix(path, ".class") {
 			return nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -20,7 +20,7 @@ func parseFile(path string) (*Classfile, error) {
 
 func TestParse(t *testing.T) {
 	t.Parallel()
-	filepath.Walk("./testdata", func(path string, info os.FileInfo, err error) error {
+	filepath.Walk("./testdata", func(path string, _ os.FileInfo, _ error) error {
 		if !strings.HasSuffix(path, ".class") {
 			return nil
 		}


### PR DESCRIPTION

<!-- octocov -->
## Code Metrics Report
| Coverage | Test Execution Time |
|---------:|--------------------:|
| 49.2%    | 18s                 |


### Code coverage of files in pull request scope (54.1%)

|                                                                      Files                                                                       | Coverage |
|--------------------------------------------------------------------------------------------------------------------------------------------------|---------:|
| [attribute.go](https://github.com/wreulicke/classfile-parser/blob/bcb72b183b1eb67947ac17d731e4909d51fa6a4a/attribute.go)                         | 16.1%    |
| [attribute_stackframe.go](https://github.com/wreulicke/classfile-parser/blob/bcb72b183b1eb67947ac17d731e4909d51fa6a4a/attribute_stackframe.go)   | 0.0%     |
| [binary/binary_parser.go](https://github.com/wreulicke/classfile-parser/blob/bcb72b183b1eb67947ac17d731e4909d51fa6a4a/binary%2Fbinary_parser.go) | 44.8%    |
| [code/parser.go](https://github.com/wreulicke/classfile-parser/blob/bcb72b183b1eb67947ac17d731e4909d51fa6a4a/code%2Fparser.go)                   | 72.8%    |
| [constant_pool.go](https://github.com/wreulicke/classfile-parser/blob/bcb72b183b1eb67947ac17d731e4909d51fa6a4a/constant_pool.go)                 | 70.6%    |
| [parser.go](https://github.com/wreulicke/classfile-parser/blob/bcb72b183b1eb67947ac17d731e4909d51fa6a4a/parser.go)                               | 49.7%    |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
